### PR TITLE
Fix scope and collection management on apps start

### DIFF
--- a/scenario/scenario.actual.spec.ts
+++ b/scenario/scenario.actual.spec.ts
@@ -41,11 +41,11 @@ describe("Couchbase actual test", () => {
   })
 
   beforeEach(async () => {
-    await breedModel.query("DELETE FROM `testing`.`_default`.`breed`")
+    await breedModel.removeAll()
   })
 
   afterEach(async () => {
-    await breedModel.query("DELETE FROM `testing`.`_default`.`breed`")
+    await breedModel.removeAll()
   })
 
   describe("Couchbase module injection test", () => {

--- a/scenario/schema/breed.ts
+++ b/scenario/schema/breed.ts
@@ -3,7 +3,7 @@ import { Key } from "../../src/util"
 
 @Schema({
   collection: "breed",
-  scope: "_default",
+  scope: "customized",
   timestamps: {
     createdAt: "created_at",
     updatedAt: "updated_at",

--- a/test/instance.spec.ts
+++ b/test/instance.spec.ts
@@ -5,15 +5,23 @@ import { CouchBaseModel, CouchBaseModule, getModelToken } from "../src"
 import { CouchBaseService } from "../src/service"
 import { Owner } from "./model/owner"
 
+var resetStore: () => void
+
 jest.mock("couchbase", () => {
+  const store = new Map<string, any>()
+  resetStore = () => {
+    store.clear()
+  }
+
   const mockManager = {
+    getAllScopes: jest.fn().mockResolvedValue([]),
     createScope: jest.fn().mockResolvedValue(undefined),
     createCollection: jest.fn().mockResolvedValue(undefined),
   }
 
   const mockBucket = {
     name: "test_bucket",
-    collections: jest.fn().mockReturnValue(mockManager),
+    collections: jest.fn(() => mockManager),
     defaultCollection: jest.fn(),
     scope: jest.fn(),
   }
@@ -22,24 +30,46 @@ jest.mock("couchbase", () => {
     name: "_default",
     bucket: jest.fn(() => mockBucket),
     collection: jest.fn(),
+    collections: [],
   }
 
   const mockCollection = {
-    insert: jest.fn().mockResolvedValue({ cas: BigInt(1) }),
-    get: jest.fn(),
-    upsert: jest.fn(),
-    replace: jest.fn(),
-    remove: jest.fn(),
+    insert: jest.fn(async (key, value) => {
+      if (store.has(key)) throw new Error("DocumentExists")
+      store.set(key, value)
+      return { cas: BigInt(1) }
+    }),
+    get: jest.fn(async (key) => {
+      if (!store.has(key)) throw new Error("DocumentNotFound")
+      return { content: store.get(key), cas: BigInt(1) }
+    }),
+    upsert: jest.fn(async (key, value) => {
+      store.set(key, value)
+      return { cas: BigInt(1) }
+    }),
+    replace: jest.fn(async (key, value) => {
+      if (!store.has(key)) throw new Error("DocumentNotFound")
+      store.set(key, value)
+      return { cas: BigInt(1) }
+    }),
+    remove: jest.fn(async (key) => {
+      store.delete(key)
+      return { cas: BigInt(1) }
+    }),
     scope: mockScope,
   }
 
+  // wire up relationships
+  mockManager.getAllScopes.mockResolvedValue([mockScope])
   mockBucket.defaultCollection.mockReturnValue(mockCollection)
-  mockBucket.scope = jest.fn(() => mockScope)
-  mockScope.collection = jest.fn(() => mockCollection)
+  mockBucket.scope.mockReturnValue(mockScope)
+  mockScope.collection.mockReturnValue(mockCollection)
 
   const mockCluster = {
     bucket: jest.fn().mockReturnValue(mockBucket),
-    query: jest.fn().mockResolvedValue({ rows: [] }),
+    query: jest.fn(async () => ({
+      rows: [...store.values()],
+    })),
     close: jest.fn().mockResolvedValue(undefined),
     diagnostics: jest.fn().mockResolvedValue({ version: "7.2.0" }),
     transactions: jest.fn().mockReturnValue({

--- a/test/module.spec.ts
+++ b/test/module.spec.ts
@@ -13,22 +13,23 @@ import { Owner } from "./model/owner"
 import { PROP_METADATA_KEY } from "../src/constant"
 import { getSchemaOptions, subChildField } from "../src/util"
 
-var resetStore: () => void;
+var resetStore: () => void
 
 jest.mock("couchbase", () => {
-  const store = new Map<string, any>();
+  const store = new Map<string, any>()
   resetStore = () => {
     store.clear()
   }
 
   const mockManager = {
+    getAllScopes: jest.fn().mockResolvedValue([]),
     createScope: jest.fn().mockResolvedValue(undefined),
     createCollection: jest.fn().mockResolvedValue(undefined),
   }
 
   const mockBucket = {
     name: "test_bucket",
-    collections: jest.fn().mockReturnValue(mockManager),
+    collections: jest.fn(() => mockManager),
     defaultCollection: jest.fn(),
     scope: jest.fn(),
   }
@@ -37,6 +38,7 @@ jest.mock("couchbase", () => {
     name: "_default",
     bucket: jest.fn(() => mockBucket),
     collection: jest.fn(),
+    collections: [],
   }
 
   const mockCollection = {
@@ -55,19 +57,21 @@ jest.mock("couchbase", () => {
     }),
     replace: jest.fn(async (key, value) => {
       if (!store.has(key)) throw new Error("DocumentNotFound")
-      store.set(key, value);
-      return { cas: BigInt(1) };
+      store.set(key, value)
+      return { cas: BigInt(1) }
     }),
     remove: jest.fn(async (key) => {
-      store.delete(key);
-      return { cas: BigInt(1) };
+      store.delete(key)
+      return { cas: BigInt(1) }
     }),
     scope: mockScope,
   }
 
+  // wire up relationships
+  mockManager.getAllScopes.mockResolvedValue([mockScope])
   mockBucket.defaultCollection.mockReturnValue(mockCollection)
-  mockBucket.scope = jest.fn(() => mockScope)
-  mockScope.collection = jest.fn(() => mockCollection)
+  mockBucket.scope.mockReturnValue(mockScope)
+  mockScope.collection.mockReturnValue(mockCollection)
 
   const mockCluster = {
     bucket: jest.fn().mockReturnValue(mockBucket),
@@ -98,7 +102,7 @@ jest.mock("couchbase", () => {
 
 beforeEach(() => {
   resetStore()
-});
+})
 
 describe("CouchbaseModule (Dynamic)", () => {
   let cluster: Cluster
@@ -293,10 +297,7 @@ describe("CouchbaseModule (Dynamic)", () => {
       const props: {
         property: string
         options: PropOptions
-      }[] = Reflect.getMetadata(
-        PROP_METADATA_KEY,
-        ownerModel.targetSchemaClass,
-      )
+      }[] = Reflect.getMetadata(PROP_METADATA_KEY, ownerModel.targetSchemaClass)
 
       const processData = await ownerModel.create(testData)
       subChildField(testData).forEach((field) => {


### PR DESCRIPTION
Close #9 

Fix `ensureScopeAndCollection` to handle collection cross scope. CB forbid to have same collection name on every scopes. So I add handler to check the collection cross the scopes